### PR TITLE
refactor: simplify loading text domain

### DIFF
--- a/payout-gateway.php
+++ b/payout-gateway.php
@@ -30,17 +30,9 @@ if (!in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get
 }
 
 function payout_load_plugin_textdomain() {
-    // Load translations from the languages directory.
-    $locale = get_locale();
-
-    // This filter is documented in /wp-includes/l10n.php.
-    $locale = apply_filters('plugin_locale', $locale, 'payout-payment-gateway'); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
-
-    load_textdomain('payout-payment-gateway', plugin_dir_path(__FILE__) . 'languages/payout-payment-gateway-' . $locale . '.mo');
-
-    load_plugin_textdomain('payout-payment-gateway', false, dirname(plugin_basename(__FILE__)) . '/languages/');
+    load_plugin_textdomain('payout-payment-gateway', false, dirname(plugin_basename(__FILE__)) . '/languages');
 }
-add_action('plugins_loaded', 'payout_load_plugin_textdomain');
+add_action('init', 'payout_load_plugin_textdomain');
 
 /**
  * Add the gateway to WC Available Gateways


### PR DESCRIPTION
- get rid of redundant calls, all of this is done in `load_plugin_textdomain()` (https://developer.wordpress.org/reference/functions/load_plugin_textdomain/#source)
- change hook to later one (https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#loading-text-domain)