### PR TITLE
feat: add hpos compatibility

### DIFF
--- a/payout-gateway.php
+++ b/payout-gateway.php
@@ -42,7 +42,7 @@ if (!class_exists('WC_Payout_One')) {
             require_once __DIR__ . '/includes/class-wc-gateway-payout.php';
 
             add_action('init', [$this, 'load_plugin_textdomain']);
-            add_action('before_woocommerce_init', 'declare_hpos_compatibility');
+            add_action('before_woocommerce_init', [$this, 'declare_hpos_compatibility']);
             add_filter('woocommerce_payment_gateways', [$this, 'add_to_wc_gateways']);
             add_filter('plugin_action_links_' . plugin_basename(__FILE__), [$this, 'plugin_action_links']);
             add_action('wp_ajax_nopriv_order_payout_status', [$this, 'order_payout_status']);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Seduco
 Tags: payout, gateway, slovakia, payment, payment gateway, platobná brána, payout payment gateway
 Requires at least: 5.0.19
 Tested up to: 6.2.2
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 Donate link: https://payout.one/
 Requires PHP: 7.0
 License: GPLv2 or later
@@ -79,6 +79,9 @@ Navštívte https://payout.one/faq/ pre podporu a často kladené otázky.
 3. Rozhranie platobnej brány
 
 == Changelog ==
+= 1.1.1 =
+* Add HPOS compatibility
+
 = 1.1.0 =
 * Major code improvements
 * Removed jQuery dependency


### PR DESCRIPTION
* fixed 2 db calls
* declared explicit compatibility
* updated version

Note: 
As discussed, please test this version on environment HPOS disabled, enabled, syncing between both storages, etc.
Attached is zip with version from this PR.
[payout-payment-gateway.zip](https://github.com/payout-one/payout_woocommerce/files/13582042/payout-payment-gateway.zip)
